### PR TITLE
Update KadNap_IOCs.txt - Fallback IP&Port

### DIFF
--- a/KadNap_IOCs.txt
+++ b/KadNap_IOCs.txt
@@ -8,6 +8,9 @@ Active as of 2/12/2026 and to the present:
 91.193.19[.]226 
 79.141.161[.]152
 
+ Hard-coded Fallback C2 IP:PORT
+193.46.217.14:13791
+
  Previous C2s 
 91.193.19[.]51
 79.141.163[.]155


### PR DESCRIPTION
Added the hard coded fallback IP&Port used by their malware

**sub_1162c** - Walk DHT peer list, deduplicate, and add fallback node address
```
result_1 = data_c6720
int32_t* result_3 = result_1
while (true)
if (result_3 == 0)
int32_t r0_24
r0_24, r1_8 = sub_88ddc(0xc, r1_8, r2_17, 0xc12ed90e)  // malloc(12)
if (r0_24 == 0)
result_1 = 0xfffffffd
r1_8 = sub_88f74(r0_24, result_3, 0xc)
*r0_24 = result_3                         // next pointer
*(r0_24 + 4) = 0xc12ed90e         // IP: 193.46.217.14
*(r0_24 + 8) = 0x35df                 // port: 13791
int32_t** result_2 = result_1
if (result_1 != 0)
while (true)
result_1 = *result_2
if (result_1 == 0)
break
result_2 = result_1
result_2 = &data_c6720
*result_2 = r0_24
break
if (result_3[1] == 0xc12ed90e)    // dedup: skip if already in list
result_1 = nullptr
break
result_3 = *result_3
```